### PR TITLE
Fix: Resolved an issue where definitions for a Structr map would strip out null values

### DIFF
--- a/src/Structr/Tree/Composite/ChoiceNode.php
+++ b/src/Structr/Tree/Composite/ChoiceNode.php
@@ -12,6 +12,7 @@ use Structr\Tree\Base\Node;
 
 use Structr\Tree\Composite\ChoicePrototypeNode;
 use Structr\Exception;
+use Structr\Tree\Scalar\NullNode;
 
 class ChoiceNode extends Node
 {
@@ -29,6 +30,19 @@ class ChoiceNode extends Node
     public function addAlternative($alternative)
     {
         $this->_alternatives[] = $alternative;
+    }
+
+    public function canHaveNullValue()
+    {
+        foreach($this->_alternatives as $alternative)
+        {
+            if(NullNode::canHaveNullValue($alternative))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/Structr/Tree/Composite/ChoiceNode.php
+++ b/src/Structr/Tree/Composite/ChoiceNode.php
@@ -9,8 +9,6 @@
 namespace Structr\Tree\Composite;
 
 use Structr\Tree\Base\Node;
-
-use Structr\Tree\Composite\ChoicePrototypeNode;
 use Structr\Exception;
 
 class ChoiceNode extends Node

--- a/src/Structr/Tree/Composite/JsonListNode.php
+++ b/src/Structr/Tree/Composite/JsonListNode.php
@@ -13,11 +13,54 @@ use Structr\Structr;
 class JsonListNode extends ListNode
 {
     /**
+     * @var array functions to apply to the value of this node
+     *      after decoding, but before checking the value of this node
+     */
+    private $_post_decode = array();
+
+    /**
+     * Add a post-decode-processing callable to this node.
+     * Post-decode-processing callables are applied to the value of this node just
+     * after the decoding the value, but just before the value is checked.
+     * The callables are applied in the order in which they are added.
+     *
+     * @param mixed $callable A valid PHP callable
+     * @throws \Structr\Exception
+     * @return \Structr\Tree\Base\Node This node
+     */
+    public function post_decode($callable)
+    {
+        if (is_callable($callable, false)) {
+            $this->_post_decode[] = $callable;
+        } else {
+            throw new Exception('Invalid callable supplied to JsonListNode::post_decode()');
+        }
+
+        return $this;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function _walk_value($value = null)
     {
         $value = Structr::json_decode($value);
+        $value = $this->_walk_post_decode($value);
         return parent::_walk_value($value);
+    }
+
+    /**
+     * Apply all post-processing callables to a value
+     *
+     * @param mixed $value The value to process
+     * @return mixed Result of all pre-processing callables
+     */
+    protected function _walk_post_decode($value)
+    {
+        foreach ($this->_post_decode as $callable) {
+            $value = call_user_func($callable, $value);
+        }
+
+        return $value;
     }
 }

--- a/src/Structr/Tree/Composite/JsonMapNode.php
+++ b/src/Structr/Tree/Composite/JsonMapNode.php
@@ -13,11 +13,54 @@ use Structr\Structr;
 class JsonMapNode extends MapNode
 {
     /**
+     * @var array functions to apply to the value of this node
+     *      after decoding, but before checking the value of this node
+     */
+    private $_post_decode = array();
+
+    /**
+     * Add a post-decode-processing callable to this node.
+     * Post-decode-processing callables are applied to the value of this node just
+     * after the decoding the value, but just before the value is checked.
+     * The callables are applied in the order in which they are added.
+     *
+     * @param mixed $callable A valid PHP callable
+     * @throws \Structr\Exception
+     * @return \Structr\Tree\Base\Node This node
+     */
+    public function post_decode($callable)
+    {
+        if (is_callable($callable, false)) {
+            $this->_post_decode[] = $callable;
+        } else {
+            throw new Exception('Invalid callable supplied to JsonMapNode::post_decode()');
+        }
+
+        return $this;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function _walk_value($value = null)
     {
         $value = Structr::json_decode($value);
+        $value = $this->_walk_post_decode($value);
         return parent::_walk_value($value);
+    }
+
+    /**
+     * Apply all post-processing callables to a value
+     *
+     * @param mixed $value The value to process
+     * @return mixed Result of all pre-processing callables
+     */
+    protected function _walk_post_decode($value)
+    {
+        foreach ($this->_post_decode as $callable) {
+            $value = call_user_func($callable, $value);
+        }
+
+        return $value;
     }
 }

--- a/src/Structr/Tree/Composite/JsonMapNode.php
+++ b/src/Structr/Tree/Composite/JsonMapNode.php
@@ -9,9 +9,37 @@
 namespace Structr\Tree\Composite;
 
 use Structr\Structr;
+use Exception;
 
 class JsonMapNode extends MapNode
 {
+    /**
+     * @var array functions to apply to the value of this node
+     *      after decoding, but before checking the value of this node
+     */
+    private $_post_decode = array();
+
+    /**
+     * Add a post-decode-processing callable to this node.
+     * Post-decode-processing callables are applied to the value of this node just
+     * after the decoding the value, but just before the value is checked.
+     * The callables are applied in the order in which they are added.
+     *
+     * @param mixed $callable A valid PHP callable
+     * @throws \Structr\Exception
+     * @return MapNode This node
+     */
+    public function post_decode($callable)
+    {
+        if (is_callable($callable, false)) {
+            $this->_post_decode[] = $callable;
+        } else {
+            throw new Exception('Invalid callable supplied to JsonMapNode::post_decode()');
+        }
+
+        return $this;
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Structr/Tree/Composite/MapKeyNode.php
+++ b/src/Structr/Tree/Composite/MapKeyNode.php
@@ -74,7 +74,7 @@ class MapKeyNode extends PrototypeNode
     public function getDescription()
     {
         $description = $this->description;
-        if(empty($description) && isset($this->_prototype)) {
+        if (empty($description) && isset($this->_prototype)) {
             $description = $this->_prototype->getDescription();
         }
         return empty($description) ? "" : $description;

--- a/src/Structr/Tree/Composite/MapNode.php
+++ b/src/Structr/Tree/Composite/MapNode.php
@@ -11,6 +11,7 @@ namespace Structr\Tree\Composite;
 use Structr\Tree\Base\Node;
 
 use Structr\Exception;
+use Structr\Tree\Scalar\NullNode;
 
 class MapNode extends Node
 {
@@ -145,6 +146,12 @@ class MapNode extends Node
             if (isset($value[$key])) {
                 $return[$key] = $val->_walk($value[$key]);
             } elseif ($val->isOptional()) {
+                if(array_key_exists($key, $value)) {
+                    if(NullNode::canHaveNullValue($value)) {
+                        $return[$key] = null;
+                    }
+                    unset($value[$key]);
+                }
                 continue;
             } else {
                 $return[$key] = $val->_walk_post($val->_walk_value_unset());

--- a/src/Structr/Tree/Composite/MapNode.php
+++ b/src/Structr/Tree/Composite/MapNode.php
@@ -145,6 +145,9 @@ class MapNode extends Node
             if (isset($value[$key])) {
                 $return[$key] = $val->_walk($value[$key]);
             } elseif ($val->isOptional()) {
+                if(array_key_exists($key, $value)) {
+                    $return[$key] = $val->_walk($value[$key]);
+                }
                 continue;
             } else {
                 $return[$key] = $val->_walk_post($val->_walk_value_unset());

--- a/src/Structr/Tree/Composite/MapNode.php
+++ b/src/Structr/Tree/Composite/MapNode.php
@@ -147,7 +147,8 @@ class MapNode extends Node
                 $return[$key] = $val->_walk($value[$key]);
             } elseif ($val->isOptional()) {
                 if(array_key_exists($key, $value)) {
-                    $return[$key] = $val->_walk($value[$key]);
+                    $return[$key] = null;
+                    unset($value[$key]);
                 }
                 continue;
             } else {

--- a/src/Structr/Tree/Scalar/NullNode.php
+++ b/src/Structr/Tree/Scalar/NullNode.php
@@ -8,7 +8,9 @@
 
 namespace Structr\Tree\Scalar;
 
+use Structr\Tree\Base\Node;
 use Structr\Tree\Base\ScalarNode;
+use Structr\Tree\Composite\ChoiceNode;
 
 class NullNode extends ScalarNode
 {
@@ -18,5 +20,21 @@ class NullNode extends ScalarNode
     public function getScalarType()
     {
         return 'NULL';
+    }
+
+    /**
+     * @param Node $node
+     */
+    public static function canHaveNullValue($node)
+    {
+        if($node instanceof NullNode) {
+            return true;
+        }
+
+        if($node instanceof ChoiceNode) {
+            return $node->canHaveNullValue();
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
h1. Issue:
When Structr was processing a map definition, it would strip out keys that had been given null values. It is important that this doesn't happen, because sometimes we want to know that a key was sent with a null value, so that we know we want to save an edit to a property by setting it to null.

For example, this input would be processed and turned into the following input:

```
{
     "propertyOne": "Hi!",
     "proeprtyTwo":
}
```
```
{
    "propertyOne": "Hi!"
}
```

h1. Solution
Check if a key has been provided with a null value, and check if the key is optional. If it is optional, allow the value to pass through as null. If it is not optional, throw an error.

Under no circumstances, remove an expected key that was sent in the payload.